### PR TITLE
Adding note about accountID format in stringData

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ stringData:
   accessKeyID: XXX # AWS AccessKeyID
   secretKey: XXXX # AWS SecretAccessKey
   region: us-east-1 # ECR repository's region to use the token for
-  accountID: 123456789  # ECR repository's account ID to use the token for
+  accountID: "123456789"  # ECR repository's account ID to use the token for
 ```
 
 The secret type should be `banzaicloud.io/aws-ecr-login-config`. 
 
-*Note*: the refresher needs list and watch Cluster permissions for secrets, and read access to the srouce secrets, and created/delete/update for the target secret.
+*Note*: the refresher needs list and watch Cluster permissions for secrets, and read access to the source secrets, and created/delete/update for the target secret.
 
 If there's interest we can provide a helm chart for the refresher too, please create an issue if you are interested.
 
@@ -131,8 +131,10 @@ stringData:
   accessKeyID: XXX # AWS AccessKeyID
   secretKey: XXXX # AWS SecretAccessKey
   region: us-east-1 # ECR repository's region to use the token for
-  accountID: 123456789  # ECR repository's account ID to use the token for
+  accountID: "123456789"  # ECR repository's account ID to use the token for
 ```
+
+*Note*: Make sure `accountID` is given as string and not bare numbers, Kubernetes Secret's `stringData` field will only accept strings. 
 
 ### Using IMPS to provision secrets in selected namespaces
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Added a note in the README

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
I've seen this error for many people recently:
```
Error from server (BadRequest): error when creating "pullsecret.yaml": Secret in version "v1" cannot be handled as a Secret: v1.Secret.StringData: ReadString: expects " or n, but found 3, error found in #10 byte of ..
```

Usually the template for ECR is just copy-pasted, so if the template had the quotation mark `"`, then it would save some time for everyone and we would not hit this error.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)