### PR TITLE
Upgrade imagepullsecrets CRD to v1

### DIFF
--- a/config/crd/bases/images.banzaicloud.io_imagepullsecrets.yaml
+++ b/config/crd/bases/images.banzaicloud.io_imagepullsecrets.yaml
@@ -1,39 +1,13 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: imagepullsecrets.images.banzaicloud.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.status
-    description: Represents if the object has been successfully reconciled
-    format: byte
-    name: State
-    type: string
-  - JSONPath: .status.lastSuccessfulReconciliation
-    description: When the object has been successfully reconciled
-    format: date
-    name: Reconciled
-    type: date
-  - JSONPath: .status.validitySeconds
-    description: How long the generated credential is valid for after the last reconciliation
-    format: int32
-    name: Validity seconds
-    type: integer
-  - JSONPath: .spec.target.secret.name
-    description: Name of the secret generated
-    format: byte
-    name: Secret Name
-    type: string
-  - JSONPath: .status.managedNamespaces
-    description: Name of the namespaces the secret is generated in
-    format: byte
-    name: Namespaces
-    type: string
   group: images.banzaicloud.io
   names:
     kind: ImagePullSecret
@@ -43,320 +17,346 @@ spec:
     - imps
     singular: imagepullsecret
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ImagePullSecret is the Schema for the imagepullsecrets API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ImagePullSecretSpec defines the desired state of ImagePullSecret
-          properties:
-            registry:
-              description: Registry contains the details of the secret to be created
-                in each namespace
-              properties:
-                credentials:
-                  description: Credentials specifies which secret to be used as the
-                    source for docker login credentials
-                  items:
+  versions:
+  - additionalPrinterColumns:
+    - description: Represents if the object has been successfully reconciled
+      format: byte
+      jsonPath: .status.status
+      name: State
+      type: string
+    - description: When the object has been successfully reconciled
+      format: date
+      jsonPath: .status.lastSuccessfulReconciliation
+      name: Reconciled
+      type: date
+    - description: How long the generated credential is valid for after the last reconciliation
+      format: int32
+      jsonPath: .status.validitySeconds
+      name: Validity seconds
+      type: integer
+    - description: Name of the secret generated
+      format: byte
+      jsonPath: .spec.target.secret.name
+      name: Secret Name
+      type: string
+    - description: Name of the namespaces the secret is generated in
+      format: byte
+      jsonPath: .status.managedNamespaces
+      name: Namespaces
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ImagePullSecret is the Schema for the imagepullsecrets API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ImagePullSecretSpec defines the desired state of ImagePullSecret
+            properties:
+              registry:
+                description: Registry contains the details of the secret to be created
+                  in each namespace
+                properties:
+                  credentials:
+                    description: Credentials specifies which secret to be used as
+                      the source for docker login credentials
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                      - name
+                      - namespace
+                      type: object
+                    type: array
+                required:
+                - credentials
+                type: object
+              target:
+                description: Target specifies what should be the name of the secret
+                  created in a given namespace
+                properties:
+                  namespaces:
+                    description: Namespaces specify conditions on the namespaces that
+                      should have the TargetSecret generated
                     properties:
+                      annotations:
+                        description: Selectors specify the conditions, which are matched
+                          against the namespaces labels to decide if this ImagePullSecret
+                          should be applied to the given namespace, if multiple selectors
+                          are specified if one is matches the secret will be managed
+                          (OR)
+                        items:
+                          properties:
+                            matchAnnotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            matchExpressions:
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                      labels:
+                        description: Labels specify the conditions, which are matched
+                          against the namespaces labels to decide if this ImagePullSecret
+                          should be applied to the given namespace, if multiple selectors
+                          are specified if one is matches the secret will be managed
+                          (OR)
+                        items:
+                          description: A label selector is a label query over a set
+                            of resources. The result of matchLabels and matchExpressions
+                            are ANDed. An empty label selector matches all objects.
+                            A null label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        type: array
+                      names:
+                        description: Namespaces specifies additional namespaces by
+                          name to generate the secret into
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  namespacesWithPods:
+                    description: Pods specify the conditions, which are matched against
+                      the pods in each namespace to decide if this ImagePullSecret
+                      should be applied to the given pod's namespace, if multiple
+                      selectors are specified if one is matches the secret will be
+                      managed (OR)
+                    properties:
+                      annotations:
+                        description: Selectors specify the conditions, which are matched
+                          against the namespaces labels to decide if this ImagePullSecret
+                          should be applied to the given namespace, if multiple selectors
+                          are specified if one is matches the secret will be managed
+                          (OR)
+                        items:
+                          properties:
+                            matchAnnotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            matchExpressions:
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                      labels:
+                        description: Labels specify the conditions, which are matched
+                          against the namespaces labels to decide if this ImagePullSecret
+                          should be applied to the given namespace, if multiple selectors
+                          are specified if one is matches the secret will be managed
+                          (OR)
+                        items:
+                          description: A label selector is a label query over a set
+                            of resources. The result of matchLabels and matchExpressions
+                            are ANDed. An empty label selector matches all objects.
+                            A null label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        type: array
+                    type: object
+                  secret:
+                    description: TargetSecretConfig describes the properties of the
+                      secrets created in each selected namespace
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations specifies additional annotations
+                          to be put on the Secret object
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels specifies additional labels to be put
+                          on the Secret object
+                        type: object
                       name:
-                        type: string
-                      namespace:
+                        description: Name specifies the name of the secret object
+                          inside all the selected namespace
                         type: string
                     required:
                     - name
-                    - namespace
                     type: object
-                  type: array
-              required:
-              - credentials
-              type: object
-            target:
-              description: Target specifies what should be the name of the secret
-                created in a given namespace
-              properties:
-                namespaces:
-                  description: Namespaces specify conditions on the namespaces that
-                    should have the TargetSecret generated
-                  properties:
-                    annotations:
-                      description: Selectors specify the conditions, which are matched
-                        against the namespaces labels to decide if this ImagePullSecret
-                        should be applied to the given namespace, if multiple selectors
-                        are specified if one is matches the secret will be managed
-                        (OR)
-                      items:
-                        properties:
-                          matchAnnotations:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          matchExpressions:
-                            items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that
-                                relates the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key that the selector
-                                    applies to.
-                                  type: string
-                                operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty.
-                                    This array is replaced during a strategic merge
-                                    patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                              - key
-                              - operator
-                              type: object
-                            type: array
-                        type: object
-                      type: array
-                    labels:
-                      description: Labels specify the conditions, which are matched
-                        against the namespaces labels to decide if this ImagePullSecret
-                        should be applied to the given namespace, if multiple selectors
-                        are specified if one is matches the secret will be managed
-                        (OR)
-                      items:
-                        description: A label selector is a label query over a set
-                          of resources. The result of matchLabels and matchExpressions
-                          are ANDed. An empty label selector matches all objects.
-                          A null label selector matches no objects.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
-                            items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that
-                                relates the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key that the selector
-                                    applies to.
-                                  type: string
-                                operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty.
-                                    This array is replaced during a strategic merge
-                                    patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                              - key
-                              - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      type: array
-                    names:
-                      description: Namespaces specifies additional namespaces by name
-                        to generate the secret into
-                      items:
-                        type: string
-                      type: array
-                  type: object
-                namespacesWithPods:
-                  description: Pods specify the conditions, which are matched against
-                    the pods in each namespace to decide if this ImagePullSecret should
-                    be applied to the given pod's namespace, if multiple selectors
-                    are specified if one is matches the secret will be managed (OR)
-                  properties:
-                    annotations:
-                      description: Selectors specify the conditions, which are matched
-                        against the namespaces labels to decide if this ImagePullSecret
-                        should be applied to the given namespace, if multiple selectors
-                        are specified if one is matches the secret will be managed
-                        (OR)
-                      items:
-                        properties:
-                          matchAnnotations:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          matchExpressions:
-                            items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that
-                                relates the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key that the selector
-                                    applies to.
-                                  type: string
-                                operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty.
-                                    This array is replaced during a strategic merge
-                                    patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                              - key
-                              - operator
-                              type: object
-                            type: array
-                        type: object
-                      type: array
-                    labels:
-                      description: Labels specify the conditions, which are matched
-                        against the namespaces labels to decide if this ImagePullSecret
-                        should be applied to the given namespace, if multiple selectors
-                        are specified if one is matches the secret will be managed
-                        (OR)
-                      items:
-                        description: A label selector is a label query over a set
-                          of resources. The result of matchLabels and matchExpressions
-                          are ANDed. An empty label selector matches all objects.
-                          A null label selector matches no objects.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
-                            items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that
-                                relates the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key that the selector
-                                    applies to.
-                                  type: string
-                                operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty.
-                                    This array is replaced during a strategic merge
-                                    patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                              - key
-                              - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      type: array
-                  type: object
-                secret:
-                  description: TargetSecretConfig describes the properties of the
-                    secrets created in each selected namespace
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations specifies additional annotations to
-                        be put on the Secret object
-                      type: object
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels specifies additional labels to be put on
-                        the Secret object
-                      type: object
-                    name:
-                      description: Name specifies the name of the secret object inside
-                        all the selected namespace
-                      type: string
-                  required:
-                  - name
-                  type: object
-              required:
-              - secret
-              type: object
-          required:
-          - registry
-          - target
-          type: object
-        status:
-          description: ImagePullSecretStatus defines the observed state of ImagePullSecret
-          properties:
-            lastSuccessfulReconciliation:
-              format: date-time
-              type: string
-            managedNamespaces:
-              items:
+                required:
+                - secret
+                type: object
+            required:
+            - registry
+            - target
+            type: object
+          status:
+            description: ImagePullSecretStatus defines the observed state of ImagePullSecret
+            properties:
+              lastSuccessfulReconciliation:
+                format: date-time
                 type: string
-              type: array
-            status:
-              type: string
-            validitySeconds:
-              format: int32
-              type: integer
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+              managedNamespaces:
+                items:
+                  type: string
+                type: array
+              status:
+                type: string
+              validitySeconds:
+                format: int32
+                type: integer
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/scripts/download-deps.sh
+++ b/scripts/download-deps.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-controller_gen_version=0.3.0
+controller_gen_version=0.6.2
 kuttl_version=0.8.0
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | mentioned in [SMM-378](https://jira-eng-sjc4.cisco.com/jira/browse/SMM-378)
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
- Upgrade controller-gen version from v0.3.0 to v0.6.2
- Upgrade imagepullsecrets.images.banzaicloud.io CRD to v1

