### PR TITLE
0.4.0: rename group from images.banzaicloud.io to images.cisco.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+## 0.4.0 - 2022-02-16
+
+This patch changes the group name of ImagePullSecrets from images.banzaicloud.io to images.cisco.com.
+
+This is a breaking change.
+
+# Upgrading
+
+To upgrade to v0.4.0 the following procedure should be followed:
+
+*Step 1)* Scale down the replicaset of IMPS to 0. This prevents IMPS from updating any pull
+secrets.
+
+*Step 2)* Change all Secrets containing ECR login information whose are referenced from any ImagePullSecrets object to
+`cisco.com/aws-ecr-login-config` (from `banzaicloud.io/aws-ecr-login-config`)
+
+*Step 3)* Install the new version of the imps helm chart.
+
+*Step 4)* Recreate all ImagePullSecrets objects with the new group of `images.cisco.com` (see [README.md](README.md) for examples)
+
+*Step 5)* Delete the old CustomResourceDefinition
+from your cluster as:
+
+```
+kubectl get imps
+```
+
+will display the CRDs with the old group information and not the new group's contents.
+
+To delete the old CRDs please execute:
+```
+kubectl delete crd imagepullsecrets.images.banzaicloud.io
+```
+

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ deploy: ensure-tools  manifests			## Deploy controller in the configured Kuberne
 # Generate manifests e.g. CRD, RBAC etc.
 .PHONY: manifests
 manifests: ensure-tools
-	${REPO_ROOT}/bin/controller-gen $(CRD_OPTIONS) rbac:roleName=binary-role object webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	cd api && ${REPO_ROOT}/bin/controller-gen $(CRD_OPTIONS) rbac:roleName=binary-role object webhook paths="./..." output:crd:artifacts:config=../config/crd/bases
 
 .PHONY: fmt
 fmt:	## Run go fmt against code

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ MAIN_PACKAGE ?= ./cmd/controller/
 
 COMMIT_HASH ?= $(shell git rev-parse --short HEAD 2>/dev/null)
 BUILD_DATE ?= $(shell date +%FT%T%z)
-VERSION ?= 0.3.5
+VERSION ?=
 LDFLAGS += -X github.com/banzaicloud/imps/internal/version.commitHash=${COMMIT_HASH}
 LDFLAGS += -X github.com/banzaicloud/imps/internal/version.buildDate=${BUILD_DATE}
 LDFLAGS += -X github.com/banzaicloud/imps/internal/version.version=${VERSION}
@@ -114,11 +114,13 @@ manifests: ensure-tools
 fmt:	## Run go fmt against code
 	go fmt ./...
 	cd deploy/charts; go fmt ./...
+	cd api; go fmt ./...
 
 .PHONY: vet
 vet:	## Run go vet against code
 	go vet ./...
 	cd deploy/charts; go vet ./...
+	cd api; go vet ./...
 
 # Generate code
 .PHONY: generate

--- a/PROJECT
+++ b/PROJECT
@@ -1,4 +1,4 @@
-domain: banzaicloud.io
+domain: cisco.com
 repo: github.com/banzaicloud/backyards/services/imp
 resources:
 - group: images

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ IMPS provides two modes of operation:
 - IMPS controller: a full fledged solution for managing and refreshing secrets in multiple namespaces
 - IMPS token refresher: a small utility that allows to refresh ECR tokens inside one namespace
 
+For list of changes please consult the [Changelog](CHANGELOG.md).
+
 ## Using the token refresher
 
 The token refresher Docker images are available in the `ghcr.io/banzaicloud/imagepullsecrets-refresher` Docker Registry.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ kind: Secret
 metadata:
   name: ecr-credentials-1
   namespace: default
-type: banzaicloud.io/aws-ecr-login-config
+type: cisco.com/aws-ecr-login-config
 stringData:
   accessKeyID: XXX # AWS AccessKeyID
   secretKey: XXXX # AWS SecretAccessKey
@@ -40,7 +40,7 @@ stringData:
   accountID: "123456789"  # ECR repository's account ID to use the token for
 ```
 
-The secret type should be `banzaicloud.io/aws-ecr-login-config`.
+The secret type should be `cisco.com/aws-ecr-login-config`.
 
 *Note*: the refresher needs list and watch Cluster permissions for secrets, and read access to the source secrets, and created/delete/update for the target secret.
 
@@ -64,7 +64,7 @@ For example the following `CustomResource` instructs IMPS to create a secret cal
 annotation:
 
 ```yaml
-apiVersion: images.banzaicloud.io/v1alpha1
+apiVersion: images.cisco.com/v1alpha1
 kind: ImagePullSecret
 metadata:
   name: imps
@@ -126,7 +126,7 @@ kind: Secret
 metadata:
   name: ecr-pull-secret
   namespace: registry-access
-type: banzaicloud.io/aws-ecr-login-config
+type: cisco.com/aws-ecr-login-config
 stringData:
   accessKeyID: XXX # AWS AccessKeyID
   secretKey: XXXX # AWS SecretAccessKey
@@ -142,7 +142,7 @@ The following CR will provision the `.spec.registry.credentials` login credentia
 `.spec.target.names.`:
 
 ```yaml
-apiVersion: images.banzaicloud.io/v1alpha1
+apiVersion: images.cisco.com/v1alpha1
 kind: ImagePullSecret
 metadata:
   name: imps
@@ -187,7 +187,7 @@ match (logical OR).
 
 For example:
 ```yaml
-apiVersion: images.banzaicloud.io/v1alpha1
+apiVersion: images.cisco.com/v1alpha1
 kind: ImagePullSecret
 metadata:
   name: imps

--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@ IMPS provides two modes of operation:
 - IMPS controller: a full fledged solution for managing and refreshing secrets in multiple namespaces
 - IMPS token refresher: a small utility that allows to refresh ECR tokens inside one namespace
 
-For list of changes please consult the [Changelog](CHANGELOG.md).
+
+## Notable changes
+
+For list of changes please consult the [changelog](CHANGELOG.md).
+
+Breaking changes:
+- *v0.4.0* updates the group of the `ImagePullSecrets` CRD from `images.banzaicloud.io` to `images.cisco.com`. For the upgrade workflow please consult the [changelog](CHANGELOG.md)
 
 ## Using the token refresher
 

--- a/api/common/secret.go
+++ b/api/common/secret.go
@@ -27,7 +27,7 @@ import (
 // nolint:gosec
 const (
 	SecretTypeBasicAuth      = "kubernetes.io/dockerconfigjson"
-	SecretTypeECRCredentials = "banzaicloud.io/aws-ecr-login-config"
+	SecretTypeECRCredentials = "cisco.com/aws-ecr-login-config"
 
 	SecretKeyDockerConfig = ".dockerconfigjson"
 

--- a/api/v1alpha1/doc.go
+++ b/api/v1alpha1/doc.go
@@ -17,5 +17,5 @@
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/banzaicloud/imps/api
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=images.banzaicloud.io
+// +groupName=images.cisco.com
 package v1alpha1

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -14,7 +14,7 @@
 
 // Package v1alpha1 contains API Schema definitions for the images v1alpha1 API group
 // +kubebuilder:object:generate=true
-// +groupName=images.banzaicloud.io
+// +groupName=images.cisco.com
 package v1alpha1
 
 import (
@@ -24,7 +24,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "images.banzaicloud.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "images.cisco.com", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -85,7 +85,7 @@ func main() {
 		MetricsBindAddress:      metricsAddr,
 		Port:                    9443,
 		LeaderElection:          enableLeaderElection,
-		LeaderElectionID:        "73de1ad9.banzaicloud.io",
+		LeaderElectionID:        "73de1ad9.cisco.com",
 		LeaderElectionNamespace: configNamespace,
 	})
 	if err != nil {

--- a/config/crd/bases/images.cisco.com_imagepullsecrets.yaml
+++ b/config/crd/bases/images.cisco.com_imagepullsecrets.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
-  name: imagepullsecrets.images.banzaicloud.io
+  name: imagepullsecrets.images.cisco.com
 spec:
-  group: images.banzaicloud.io
+  group: images.cisco.com
   names:
     kind: ImagePullSecret
     listKind: ImagePullSecretList

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,7 +2,7 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/images.banzaicloud.io_imagepullsecrets.yaml
+- bases/images.cisco.com_imagepullsecrets.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,7 +19,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - images.banzaicloud.io
+  - images.cisco.com
   resources:
   - imagepullsecrets
   verbs:
@@ -31,7 +31,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - images.banzaicloud.io
+  - images.cisco.com
   resources:
   - imagepullsecrets/status
   verbs:

--- a/config/samples/images_v1alpha1_imagepullsecrets.yaml
+++ b/config/samples/images_v1alpha1_imagepullsecrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: images.banzaicloud.io/v1alpha1
+apiVersion: images.cisco.com/v1alpha1
 kind: ImagePullSecrets
 metadata:
   labels:

--- a/controllers/const.go
+++ b/controllers/const.go
@@ -15,5 +15,5 @@
 package controllers
 
 const (
-	labelImpsOwnerUID = "images.banzaicloud.io/owner-uid"
+	labelImpsOwnerUID = "images.cisco.com/owner-uid"
 )

--- a/controllers/imagepullsecret_controller.go
+++ b/controllers/imagepullsecret_controller.go
@@ -48,8 +48,8 @@ type ImagePullSecretReconciler struct {
 	PeriodicReconcileInterval time.Duration
 }
 
-// +kubebuilder:rbac:groups=images.banzaicloud.io,resources=imagepullsecrets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=images.banzaicloud.io,resources=imagepullsecrets/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=images.cisco.com,resources=imagepullsecrets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=images.cisco.com,resources=imagepullsecrets/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;update;patch
 func (r *ImagePullSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/deploy/charts/imagepullsecrets/Chart.yaml
+++ b/deploy/charts/imagepullsecrets/Chart.yaml
@@ -9,5 +9,5 @@ maintainers:
 sources:
 - https://github.com/banzaicloud/backyards
 
-version:
-appVersion:
+version: v0.4.0
+appVersion: v0.4.0

--- a/deploy/charts/imagepullsecrets/Chart.yaml
+++ b/deploy/charts/imagepullsecrets/Chart.yaml
@@ -9,5 +9,5 @@ maintainers:
 sources:
 - https://github.com/banzaicloud/backyards
 
-version: 0.3.5
-appVersion: 0.3.5
+version:
+appVersion:

--- a/deploy/charts/imagepullsecrets/crds/crds.yaml
+++ b/deploy/charts/imagepullsecrets/crds/crds.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
-  name: imagepullsecrets.images.banzaicloud.io
+  name: imagepullsecrets.images.cisco.com
 spec:
-  group: images.banzaicloud.io
+  group: images.cisco.com
   names:
     kind: ImagePullSecret
     listKind: ImagePullSecretList

--- a/deploy/charts/imagepullsecrets/examples/test.yaml
+++ b/deploy/charts/imagepullsecrets/examples/test.yaml
@@ -13,7 +13,7 @@ metadata:
 stringData:
   test: "test12345"
 ---
-apiVersion: images.banzaicloud.io/v1alpha1
+apiVersion: images.cisco.com/v1alpha1
 kind: ImagePullSecret
 metadata:
   name: imps-test-1

--- a/deploy/charts/imagepullsecrets/templates/default_imps_cr.yaml
+++ b/deploy/charts/imagepullsecrets/templates/default_imps_cr.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.defaultConfig.enabled }}
 ---
-apiVersion: images.banzaicloud.io/v1alpha1
+apiVersion: images.cisco.com/v1alpha1
 kind: ImagePullSecret
 metadata:
   name: {{ include "imagepullsecret-controller.fullname" . }}-default

--- a/deploy/charts/imagepullsecrets/templates/deployment.yaml
+++ b/deploy/charts/imagepullsecrets/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         backyards.banzaicloud.io/operator-release: stable
         {{- end }}
         {{- if .Values.istio.revision }}
-        istio.banzaicloud.io/rev: {{ .Values.istio.revision }}
+        istio.io/rev: {{ .Values.istio.revision }}
         {{- end }}
     {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/imagepullsecrets/templates/rbac.yaml
+++ b/deploy/charts/imagepullsecrets/templates/rbac.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     {{- include "imagepullsecret-controller.labels" . | nindent 4 }}
 rules:
-- apiGroups: ["images.banzaicloud.io"]
+- apiGroups: ["images.cisco.com"]
   resources: ["*"]
   verbs:
   - get
@@ -48,7 +48,7 @@ rules:
     - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role 
+kind: Role
 metadata:
   name: {{ include "imagepullsecret-controller.fullname" . }}
   namespace: {{ .Release.Namespace }}

--- a/deploy/charts/imagepullsecrets/values.yaml
+++ b/deploy/charts/imagepullsecrets/values.yaml
@@ -16,7 +16,7 @@ securityContext:
   allowPrivilegeEscalation: false
 image:
   repository: ghcr.io/banzaicloud/imagepullsecrets
-  tag: v0.3.5
+  tag: v
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	emperror.dev/handler/logur v0.5.0
 	github.com/aws/aws-sdk-go-v2 v1.2.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.1.1
-	github.com/banzaicloud/imps/api v0.3.5
+	github.com/banzaicloud/imps/api v0.4.0
 	github.com/banzaicloud/operator-tools v0.24.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/pflag v1.0.5
@@ -89,6 +89,4 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-replace (
-	github.com/banzaicloud/imps/api => ./api
-)
+replace github.com/banzaicloud/imps/api => ./api


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | **yes**
| Deprecations?   | **yes**
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


This patch changes the group name of ImagePullSecrets from images.banzaicloud.io to images.cisco.com.

This is a breaking change.

# Upgrading

To upgrade to v0.4.0 the following procedure should be followed:

*Step 1)* Scale down the replicaset of IMPS to 0. This prevents IMPS from updating any pull
secrets.

*Step 2)* Change all Secrets containing ECR login information whose are referenced from any ImagePullSecrets object to
`cisco.com/aws-ecr-login-config` (from `banzaicloud.io/aws-ecr-login-config`)

*Step 3)* Install the new version of the imps helm chart.

*Step 4)* Recreate all ImagePullSecrets objects with the new group of `images.cisco.com` (see [README.md](README.md) for examples)

*Step 5)* Delete the old CustomResourceDefinition
from your cluster as:

```
kubectl get imps
```

will display the CRDs with the old group information and not the new group's contents.

To delete the old CRDs please execute:
```
kubectl delete crd imagepullsecrets.images.banzaicloud.io
```


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
 This breaking change renames the imagepullsecrets CRD's group from images.banzaicloud.io to images.cisco.com to reflect that this project  is part of the Cisco ecosystem.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
