### PR TITLE
Prepare release v0.3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2019 Banzai Cloud Zrt. All Rights Reserved.
 ARG FROM_IMAGE=scratch
-ARG GO_VERSION=1.17
+ARG GO_VERSION=1.18
 
 # Build the manager binary
 FROM golang:${GO_VERSION}-alpine3.14 as builder

--- a/Dockerfile-refresher
+++ b/Dockerfile-refresher
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Banzai Cloud Zrt. All Rights Reserved.
 
 ARG FROM_IMAGE=scratch
-ARG GO_VERSION=1.16
+ARG GO_VERSION=1.18
 
 # Build the manager binary
 FROM golang:${GO_VERSION}-alpine3.14 as builder

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ MAIN_PACKAGE ?= ./cmd/controller/
 
 COMMIT_HASH ?= $(shell git rev-parse --short HEAD 2>/dev/null)
 BUILD_DATE ?= $(shell date +%FT%T%z)
-VERSION ?= 0.3.5
+VERSION ?= 0.3.6
 LDFLAGS += -X github.com/banzaicloud/imps/internal/version.commitHash=${COMMIT_HASH}
 LDFLAGS += -X github.com/banzaicloud/imps/internal/version.buildDate=${BUILD_DATE}
 LDFLAGS += -X github.com/banzaicloud/imps/internal/version.version=${VERSION}

--- a/deploy/charts/imagepullsecrets/Chart.yaml
+++ b/deploy/charts/imagepullsecrets/Chart.yaml
@@ -9,5 +9,5 @@ maintainers:
 sources:
 - https://github.com/banzaicloud/backyards
 
-version: 0.3.5
-appVersion: 0.3.5
+version: 0.3.6
+appVersion: 0.3.6

--- a/deploy/charts/imagepullsecrets/values.yaml
+++ b/deploy/charts/imagepullsecrets/values.yaml
@@ -16,7 +16,7 @@ securityContext:
   allowPrivilegeEscalation: false
 image:
   repository: ghcr.io/banzaicloud/imagepullsecrets
-  tag: v0.3.5
+  tag: v0.3.6
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.10.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.1.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.0
-	github.com/banzaicloud/imps/api v0.3.5
+	github.com/banzaicloud/imps/api v0.3.6
 	github.com/banzaicloud/operator-tools v0.24.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/pflag v1.0.5

--- a/pkg/ecr/token.go
+++ b/pkg/ecr/token.go
@@ -50,7 +50,6 @@ func NewECRToken(ctx context.Context, creds StringableCredentials) (*Token, erro
 }
 
 func (t *Token) Refresh(ctx context.Context) error {
-
 	client := ecr.NewFromConfig(t.Creds.ToAwsConfig())
 
 	// note: RegistryIds is deprecated, any account's registries can be accessed via the returned token

--- a/pkg/ecr/types.go
+++ b/pkg/ecr/types.go
@@ -17,6 +17,7 @@ package ecr
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/sts"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | PR-20
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Prepare for release v0.3.6. 

Only new feature is:
- Incluson of `RoleArn` according to https://github.com/banzaicloud/imps/pull/20.

Security fix:
- Use go 1.18 for building the project, so that we are on the latest baseline.

Helm charts are updated to reference the new version of images.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)
