### PR TITLE
Fix github actions branch name to `main`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Docker
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+"

--- a/.github/workflows/docker_refresher.yml
+++ b/.github/workflows/docker_refresher.yml
@@ -3,7 +3,7 @@ name: Docker
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+"

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -3,7 +3,7 @@ name: Helm charts
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - "deploy/charts/v[0-9]+.[0-9]+.[0-9]+"
   pull_request:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes github actions branch to main
| License         | Apache 2.0


### What's in this PR?
Fix github branch name to `main`

### Why?
1. GitHub actions are not triggering after committing to `main` branch as it was set as `master` on github workflow
2. Also, fixed the `latest` tag on image registry https://github.com/banzaicloud/imps/pkgs/container/imagepullsecrets

### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)