### PR TITLE
Fixed CI GHA Helm push

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -65,7 +65,7 @@ jobs:
         id: set-helm-push-enabled
         run: |
           HELM_PUSH_ENABLED=""
-          if [ "${{ github.event_name }}" == "push" ] && echo "${{ steps.set-git-refname.outputs.git_refname }}" | grep -E -q "^(chart/)?[^/]+/[0-9]+\.[0-9]+\.[0-9]+"; then
+          if [ "${{ github.event_name }}" == "push" ] && echo "${{ steps.set-git-refname.outputs.git_refname }}" | grep -E -q "^(deploy/charts/v)?[^/]+/[0-9]+\.[0-9]+\.[0-9]+"; then
             HELM_PUSH_ENABLED=1
           else
             printf >&2 "Unstable chart (%s) from %s event, chart will not be pushed" "${{ steps.set-git-refname.outputs.git_refname }}" "${{ github.event_name }}"
@@ -78,7 +78,7 @@ jobs:
         name: Set chart name
         id: set-chart-name
         run: |
-          CHART_NAME="$(echo "${{ steps.set-git-refname.outputs.git_refname }}}" | awk -F '/' '{print $(NF-1)}')"
+          CHART_NAME="imagepullsecrets"
 
           echo "CHART_NAME=${CHART_NAME}"
           echo "chart_name=${CHART_NAME}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no (CI so technically not IMPS patch, but still crucial)
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed the GHA CI Helm push workflow to be able to function properly on real final chart pushing.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The chart pushing mechanism in the CI is broken.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


In #22 the CI was moved from CircleCI to GHA with the generic Helm workflow that originates from my Cloudinfo CircleCI->GHA migration. This missed the fact the repository uses a `deploy` folder to contain the charts which the generic solution didn't incorporate for.

Then came the PR #24 which updated the workflows to work on the deploy tags not the chart ones.
This repo is tagging both a `chart/imagepullsecrets/x.y.z` and a `deploy/charts/vx.y.z` tags for a chart release in addition to the `vx.y.z` tag of IMPS itself.
With the modification in #24 the GHA workflow was triggering on the deploy tag but the workflow hasn't been properly migrated, because 2 issues remained:
1. the final chart tag was expected to be in the `chart/imagepullsecrets/x.y.z` form, this part of the workflow hasn't been updated.
2. the chart name was supposed to be derived from the tag itself as it is done for other repos, but the newly used `deploy/charts/vx.y.z` tag does not use the name in itself so it was impossible to derive the chart name and subsequently the path from it which would have broken the chart packaging process even if the first issue would have been fixed.

Because I don't know the reason behind why we transitioned from chart/... to deploy/... tags on charts - but multiple people reviewed it and approved it whom I want to trust - I decided the fastest path to fixing this is to migrate the workflow properly to the new tag usage.

Edit: the reason for the deploy tag schema is pulling the chart folder in for Go dependency in other projects.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
