### PR TITLE
Fixed CI Helm push version comparison

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -97,7 +97,7 @@ jobs:
         name: Check Helm chart version in repository
         run: |
           CHART_PATH="${{ github.workspace }}/deploy/charts/${{ steps.set-chart-name.outputs.chart_name }}"
-          EXPECTED_CHART_VERSION="$(echo "${{ steps.set-git-refname.outputs.git_refname }}" | awk -F '/' '{print $NF}')" || exit 1
+          EXPECTED_CHART_VERSION="$(echo "${{ steps.set-git-refname.outputs.git_refname }}" | awk -F '/v' '{print $NF}')" || exit 1
           ACTUAL_CHART_VERSION="$(awk '/version: [0-9]+\.[0-9]+\.[0-9]+/ {print $2}' "${CHART_PATH}/Chart.yaml")" || exit 1
 
           if [ "${EXPECTED_CHART_VERSION}" != "${ACTUAL_CHART_VERSION}" ]; then


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no (CI bug)
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed CI Helm push version comparison.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Because the modified tag generates a modified expected version unless the v prefix is cut off.
https://github.com/banzaicloud/imps/actions/runs/4379382137/jobs/7665273064#step:12:21

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

There are no more usages of the damn tag so it should be fine now.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
