### PR TITLE
Add Red Hat UBI base image for imps-refresher image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Check dependency licenses
         env:
           GITHUB_TOKEN: ${{ github.token }} # Note: this is required for licensei auth in steps to avoid rate-limiting.
-        run: make license-check
+        run: go mod vendor && make license-check
 
       - name: Run lint
         run: GOLANGCI_VERSION=${{ env.GOLANGCI_LINT_VERSION }} make lint

--- a/.github/workflows/docker_refresher.yml
+++ b/.github/workflows/docker_refresher.yml
@@ -61,3 +61,15 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
           tags: |
             ghcr.io/banzaicloud/imagepullsecrets-refresher:${{ steps.imagetag.outputs.value }}
+      - name: Build imagepullsecrets refresher with Red Hat UBI base image
+        uses: docker/build-push-action@v3
+        with:
+          file: Dockerfile-refresher
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          build-args: |
+            FROM_IMAGE=redhat/ubi8-micro
+          tags: |
+            ghcr.io/banzaicloud/imagepullsecrets-refresher-rh-ubi8:${{ steps.imagetag.outputs.value }}

--- a/Dockerfile-refresher
+++ b/Dockerfile-refresher
@@ -38,6 +38,7 @@ WORKDIR /
 COPY --from=builder /etc/nsswitch.conf.build /etc/nsswitch.conf
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /workspace/LICENSE.md /licenses/LICENSE.md
 
 COPY --from=builder /workspace/manager .
 USER nobody:nobody


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
`imagepullsecrets-refresher` container is installed by the `smm-operator` helm chart and Red Hat certification of Cisco's Calisti `1.12` on OpenShift requires all images installed by the `smm-operator` helm chart to have [Red Hat UBI (Universal Base Image)](https://developers.redhat.com/products/rhel/ubi) as the base image and the [`/licenses` directory](https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.59/html/red_hat_openshift_software_certification_policy_guide/assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction). So, adding them for `imagepullsecrets-refresher` image and updated `.github/workflows/docker_refresher.yml` to build a new `imagepullsecrets-refresher` image with UBI base image.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Needed for Red Hat certification of Cisco's Calisti `1.12` on OpenShift.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

### Test results:
```
docker build . --build-arg FROM_IMAGE=redhat/ubi8-micro  -f Dockerfile-refresher -t testtag/smm/imagepullsecrets-refresher:rh-ubi8

$ docker images
REPOSITORY                               TAG       IMAGE ID       CREATED          SIZE
testtag/smm/imagepullsecrets-refresher   rh-ubi8   ca3be1077a2d   24 seconds ago   75.6MB

# image has Red Hat UBI base image
$ docker inspect ca3be1077a2d | grep -i ubi
            "testtag/smm/imagepullsecrets-refresher:rh-ubi8"
                "com.redhat.component": "ubi8-micro-container",
                "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
                "io.k8s.display-name": "Ubi8-micro",
                "name": "ubi8/ubi-micro",
                "summary": "ubi8 micro image",
                "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/ubi-micro/images/8.7-8",

# image has /licenses directory with the license
$ docker run --rm -it --entrypoint="/bin/sh" testtag/smm/imagepullsecrets-refresher:rh-ubi8
sh-4.4$ ls -l /licenses/LICENSE.md 
-rw-r--r-- 1 root root 11357 Apr 10 17:03 /licenses/LICENSE.md
sh-4.4$ cat /licenses/LICENSE.md 
sh-4.4$ exit
```