### PR TITLE
Use UBI redhat/ubi8-micro:8.7 for imps-refresher

### DIFF
--- a/.github/workflows/docker_refresher.yml
+++ b/.github/workflows/docker_refresher.yml
@@ -70,6 +70,6 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           build-args: |
-            FROM_IMAGE=redhat/ubi8-micro
+            FROM_IMAGE=redhat/ubi8-micro:8.7
           tags: |
             ghcr.io/banzaicloud/imagepullsecrets-refresher-rh-ubi8:${{ steps.imagetag.outputs.value }}


### PR DESCRIPTION

### What's in this PR?
Circle CI Docker build fails using `redhat/ubi8-micro` with the `latest` tag. Chances are while images are rebuilding on Dockerhub, the "latest" tag will become momentarily unavailable while updating. We will use the tag `8.7` instead.