### PR TITLE
Remove linux/arm/v7 platform support for UBI based image

### DIFF
--- a/.github/workflows/docker_refresher.yml
+++ b/.github/workflows/docker_refresher.yml
@@ -65,7 +65,8 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           file: Dockerfile-refresher
-          platforms: ${{ env.PLATFORMS }}
+          # Red Hat UBI doesn't support linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
Looks like no ubi8-micro available for `linux/arm/v7`

https://hub.docker.com/r/redhat/ubi8-micro/tags