### PR TITLE
Improve ci

### DIFF
--- a/.github/.editorconfig
+++ b/.github/.editorconfig
@@ -1,0 +1,2 @@
+[{*.yml,*.yaml}]
+indent_size = 2

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/analysis-codeql.yaml
+++ b/.github/workflows/analysis-codeql.yaml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+  schedule:
+    - cron: '21 16 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ go ]
+
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@d186a2a36cc67bfa1b860e6170d37fb9634742c7 # v2.2.11
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@d186a2a36cc67bfa1b860e6170d37fb9634742c7 # v2.2.11
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@d186a2a36cc67bfa1b860e6170d37fb9634742c7 # v2.2.11

--- a/.github/workflows/analysis-scorecard.yaml
+++ b/.github/workflows/analysis-scorecard.yaml
@@ -1,0 +1,47 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '30 0 * * 5'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@80e868c13c90f172d68d1f4501dee99e2479f7af # v2.1.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload results as artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: OpenSSF Scorecard results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@d186a2a36cc67bfa1b860e6170d37fb9634742c7 # v2.2.11
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -1,0 +1,322 @@
+name: Artifacts
+
+on:
+  workflow_call:
+    inputs:
+      publish:
+        description: Publish artifacts to the artifact store
+        default: false
+        required: false
+        type: boolean
+    outputs:
+      controller-image-name:
+        description: Controller image name
+        value: ${{ jobs.controller-image.outputs.name }}
+      controller-image-digest:
+        description: Controller image digest
+        value: ${{ jobs.controller-image.outputs.digest }}
+      controller-image-ref:
+        description: Controller image ref
+        value: ${{ jobs.controller-image.outputs.ref }}
+      refresher-image-name:
+        description: Refresher image name
+        value: ${{ jobs.refresher-image.outputs.name }}
+      refresher-image-digest:
+        description: Refresher image digest
+        value: ${{ jobs.refresher-image.outputs.digest }}
+      refresher-image-ref:
+        description: Refresher image ref
+        value: ${{ jobs.refresher-image.outputs.ref }}
+
+permissions:
+  contents: read
+
+jobs:
+  controller-image:
+    name: Controller image
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      security-events: write
+
+    outputs:
+      name: ${{ steps.image-name.outputs.value }}
+      digest: ${{ steps.build.outputs.digest }}
+      ref: ${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c # v2.5.0
+
+      - name: Set up Cosign
+        uses: sigstore/cosign-installer@9e9de2292db7abb3f51b7f4808d98f0d347a8919 # v3.0.2
+        with:
+          cosign-release: v2.0.1
+        if: inputs.publish
+
+      - name: Set up Syft
+        uses: anchore/sbom-action/download-syft@422cb34a0f8b599678c41b21163ea6088edb2624 # v0.14.1
+        with:
+          syft-version: v0.76.1
+
+      - name: Set image name
+        id: image-name
+        run: echo "value=ghcr.io/banzaicloud/imagepullsecrets" >> "$GITHUB_OUTPUT"
+
+      - name: Gather build metadata
+        id: meta
+        uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 # v4.3.0
+        with:
+          images: ${{ steps.image-name.outputs.value }}
+          flavor: |
+            latest = false
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{raw}}
+            type=raw,value=latest,enable=${{ github.ref_name == github.event.repository.default_branch }}
+
+      # Multiple exporters are not supported yet
+      # See https://github.com/moby/buildkit/pull/2760
+      - name: Determine build output
+        uses: haya14busa/action-cond@1d6e8a12b20cdb4f1954feef9aa475b9c390cab5 # v1.1.1
+        id: build-output
+        with:
+          cond: ${{ inputs.publish }}
+          if_true: type=image,push=true
+          if_false: type=oci,dest=image.tar
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+        if: inputs.publish
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: ${{ steps.build-output.outputs.value }}
+          # push: ${{ inputs.publish }}
+
+      - name: Fetch image
+        run: skopeo --insecure-policy copy docker://${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }} oci-archive:image.tar
+        if: inputs.publish
+
+      - name: Extract OCI tarball
+        run: |
+          mkdir -p image
+          tar -xf image.tar -C image
+
+      # See https://github.com/anchore/syft/issues/1545
+      - name: Extract image from multi-arch image
+        run: skopeo --override-os linux --override-arch amd64 --insecure-policy copy oci:image docker-archive:docker.tar
+
+      - name: Generate SBOM
+        run: syft -o spdx-json=sbom-spdx.json docker-archive:docker.tar
+
+      - name: Upload SBOM as artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: Controller image SBOM
+          path: sbom-spdx.json
+          retention-days: 5
+
+      - name: Sign image
+        run: |
+          cosign sign --yes --recursive "${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }}"
+          echo "::notice title=Verify signature::cosign verify --certificate-identity 'https://github.com/${{ github.workflow_ref }}' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' ${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }}"
+          echo "::notice title=Verify signature(pretty print)::cosign verify --certificate-identity 'https://github.com/${{ github.workflow_ref }}' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' ${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }} | jq '.[0]'"
+        if: inputs.publish
+
+      - name: Attach SBOM attestation
+        run: |
+          cosign attest --yes --predicate sbom-spdx.json --type spdx "${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }}"
+          echo "::notice title=Verify SBOM attestation::cosign verify-attestation --certificate-identity 'https://github.com/${{ github.workflow_ref }}' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' --type spdx ${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }}"
+          echo "::notice title=Inspect SBOM::cosign verify-attestation --certificate-identity 'https://github.com/${{ github.workflow_ref }}' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' --type spdx ${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }} | jq '.payload |= @base64d | .payload | fromjson | select(.predicateType == \"https://spdx.dev/Document\") | .predicate | fromjson'"
+        if: inputs.publish
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@1f0aa582c8c8f5f7639610d6d38baddfea4fdcee # 0.9.2
+        with:
+          input: image
+          format: sarif
+          output: trivy-results.sarif
+
+      - name: Upload Trivy scan results as artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: Trivy scan results for controller image
+          path: trivy-results.sarif
+          retention-days: 5
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@d186a2a36cc67bfa1b860e6170d37fb9634742c7 # v2.2.11
+        with:
+          sarif_file: trivy-results.sarif
+
+  refresher-image:
+    name: Refresher image
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        target: [ "distroless", "ubi8" ]
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      security-events: write
+
+    outputs:
+      name: ${{ steps.image-name.outputs.value }}
+      digest: ${{ steps.build.outputs.digest }}
+      ref: ${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c # v2.5.0
+
+      - name: Set up Cosign
+        uses: sigstore/cosign-installer@9e9de2292db7abb3f51b7f4808d98f0d347a8919 # v3.0.2
+        with:
+          cosign-release: v2.0.1
+        if: inputs.publish
+
+      - name: Set up Syft
+        uses: anchore/sbom-action/download-syft@422cb34a0f8b599678c41b21163ea6088edb2624 # v0.14.1
+        with:
+          syft-version: v0.76.1
+
+      - name: Set image name
+        id: image-name
+        run: echo "value=ghcr.io/banzaicloud/imagepullsecrets-refresher" >> "$GITHUB_OUTPUT"
+
+      - name: Gather build metadata
+        id: meta
+        uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 # v4.3.0
+        with:
+          images: ${{ steps.image-name.outputs.value }}
+          flavor: |
+            latest = false
+          tags: |
+            type=ref,event=branch,suffix=-${{ matrix.target }}
+            type=ref,event=pr,suffix=-${{ matrix.target }}
+            type=semver,pattern={{raw}},suffix=-${{ matrix.target }}
+            type=semver,pattern={{raw}},enable=${{ matrix.target == 'distroless' }}
+            type=raw,value=latest,suffix=-${{ matrix.target }},enable=${{ github.ref_name == github.event.repository.default_branch }}
+            type=raw,value=latest,enable=${{ github.ref_name == github.event.repository.default_branch && matrix.target == 'distroless' }}
+
+      # Multiple exporters are not supported yet
+      # See https://github.com/moby/buildkit/pull/2760
+      - name: Determine build output
+        uses: haya14busa/action-cond@1d6e8a12b20cdb4f1954feef9aa475b9c390cab5 # v1.1.1
+        id: build-output
+        with:
+          cond: ${{ inputs.publish }}
+          if_true: type=image,push=true
+          if_false: type=oci,dest=image.tar
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+        if: inputs.publish
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
+        with:
+          context: .
+          file: Dockerfile-refresher
+          target: ${{ matrix.target }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: ${{ steps.build-output.outputs.value }}
+          # push: ${{ inputs.publish }}
+
+      - name: Fetch image
+        run: skopeo --insecure-policy copy docker://${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }} oci-archive:image.tar
+        if: inputs.publish
+
+      - name: Extract OCI tarball
+        run: |
+          mkdir -p image
+          tar -xf image.tar -C image
+
+      # See https://github.com/anchore/syft/issues/1545
+      - name: Extract image from multi-arch image
+        run: skopeo --override-os linux --override-arch amd64 --insecure-policy copy oci:image docker-archive:docker.tar
+
+      - name: Generate SBOM
+        run: syft -o spdx-json=sbom-spdx.json docker-archive:docker.tar
+
+      - name: Upload SBOM as artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: Refresher image SBOM
+          path: sbom-spdx.json
+          retention-days: 5
+
+      - name: Sign image
+        run: |
+          cosign sign --yes --recursive "${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }}"
+          echo "::notice title=Verify signature::cosign verify --certificate-identity 'https://github.com/${{ github.workflow_ref }}' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' ${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }}"
+          echo "::notice title=Verify signature(pretty print)::cosign verify --certificate-identity 'https://github.com/${{ github.workflow_ref }}' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' ${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }} | jq '.[0]'"
+        if: inputs.publish
+
+      - name: Attach SBOM attestation
+        run: |
+          cosign attest --yes --predicate sbom-spdx.json --type spdx "${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }}"
+          echo "::notice title=Verify SBOM attestation::cosign verify-attestation --certificate-identity 'https://github.com/${{ github.workflow_ref }}' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' --type spdx ${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }}"
+          echo "::notice title=Inspect SBOM::cosign verify-attestation --certificate-identity 'https://github.com/${{ github.workflow_ref }}' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' --type spdx ${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }} | jq '.payload |= @base64d | .payload | fromjson | select(.predicateType == \"https://spdx.dev/Document\") | .predicate | fromjson'"
+        if: inputs.publish
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@1f0aa582c8c8f5f7639610d6d38baddfea4fdcee # 0.9.2
+        with:
+          input: image
+          format: sarif
+          output: trivy-results.sarif
+
+      - name: Upload Trivy scan results as artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: Trivy scan results for refresher image
+          path: trivy-results.sarif
+          retention-days: 5
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@d186a2a36cc67bfa1b860e6170d37fb9634742c7 # v2.2.11
+        with:
+          sarif_file: trivy-results.sarif

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,3 +125,14 @@ jobs:
 
       - name: Run tests
         run: make test
+
+  artifacts:
+    name: Artifacts
+    uses: ./.github/workflows/artifacts.yaml
+    with:
+      publish: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      security-events: write

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,11 +3,12 @@ name: Docker
 on:
   push:
     branches:
-      - main
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
+      - disabled
+    #   - main
+    # tags:
+    #   - "v[0-9]+.[0-9]+.[0-9]+"
+    #   - "v[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+"
+    #   - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
 
 env:
   PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/docker_refresher.yml
+++ b/.github/workflows/docker_refresher.yml
@@ -3,11 +3,12 @@ name: Docker
 on:
   push:
     branches:
-      - main
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
+      - disabled
+    #   - main
+    # tags:
+    #   - "v[0-9]+.[0-9]+.[0-9]+"
+    #   - "v[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+"
+    #   - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
 
 env:
   PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
+
+permissions:
+  contents: read
+
+jobs:
+  artifacts:
+    name: Artifacts
+    uses: ./.github/workflows/artifacts.yaml
+    with:
+      publish: true
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      security-events: write

--- a/Dockerfile-refresher
+++ b/Dockerfile-refresher
@@ -31,7 +31,21 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM ${FROM_IMAGE}
+FROM redhat/ubi8-micro:8.7 AS ubi8
+
+WORKDIR /
+
+COPY --from=builder /etc/nsswitch.conf.build /etc/nsswitch.conf
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /workspace/LICENSE.md /licenses/LICENSE.md
+
+COPY --from=builder /workspace/manager .
+USER nobody:nobody
+
+ENTRYPOINT ["/manager"]
+
+FROM gcr.io/distroless/base-debian11:latest AS distroless
 
 WORKDIR /
 


### PR DESCRIPTION
Improve CI and container image building.

Important change: the base image (distroless/ubi8) is now part of the tag, not the image name. Image variants should use the tag, not the image name to represent such information.

Also fixes #34

I'll submit a number of other improvements once this is merged.