### PR TITLE
Add UID:GID to imps and imps-refresher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,10 @@ generate-helm-crds: ensure-tools	## Update the CRDs in our helm charts
 docker-build: test		## Build the docker image (to override image name please set IMG)
 	docker build . --build-arg LDFLAGS="${LDFLAGS}" -f ${CURDIR}/Dockerfile -t ${IMG}
 
+.PHONY: docker-build-refresher
+docker-build-refresher: test		## Build the docker image (to override image name please set IMG)
+	docker build . --build-arg LDFLAGS="${LDFLAGS}" -f ${CURDIR}/Dockerfile-refresher -t ${IMG}
+
 .PHONY: docker-push
 docker-push:			## Push the docker image (to override image name please set IMG)
 	docker push ${IMG}

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ RACE_DETECTOR ?= 0
 CHART_NAME = imagepullsecrets
 
 # Image URL to use all building/pushing image targets
-IMG ?= imagepullsecrects:latest
+IMG ?= imagepullsecrets:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd"
 # TODO: Use this when allowDangerousTypes feature is released to support floats


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #48 
| License         | Apache 2.0

### What's in this PR?
Add run as user UID:GID to imps and imps-refresher container images

### Why?
Recent commit #48 resulted in removal of USER UID:GID required to support Openshift and non-Openshift deployment of imps and imps-refresher images

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### Testing
```
❯ k get pods -A | grep smm
smm-registry-access   smm-operator-0                                       2/2     Running   0               40s
smm-registry-access   smm-operator-ecr-token-fetcher-94b67df68-2cccp       1/1     Running   0               40s
❯
❯ kubectl config current-context
nispatil-eks
```