### PR TITLE
Bump helm chart to 0.3.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ MAIN_PACKAGE ?= ./cmd/controller/
 
 COMMIT_HASH ?= $(shell git rev-parse --short HEAD 2>/dev/null)
 BUILD_DATE ?= $(shell date +%FT%T%z)
-VERSION ?= 0.3.10
+VERSION ?= 0.3.11
 LDFLAGS += -X github.com/banzaicloud/imps/internal/version.commitHash=${COMMIT_HASH}
 LDFLAGS += -X github.com/banzaicloud/imps/internal/version.buildDate=${BUILD_DATE}
 LDFLAGS += -X github.com/banzaicloud/imps/internal/version.version=${VERSION}

--- a/deploy/charts/imagepullsecrets/Chart.yaml
+++ b/deploy/charts/imagepullsecrets/Chart.yaml
@@ -9,5 +9,5 @@ maintainers:
 sources:
 - https://github.com/banzaicloud/backyards
 
-version: 0.3.10
-appVersion: 0.3.10
+version: 0.3.11
+appVersion: 0.3.11

--- a/deploy/charts/imagepullsecrets/values.yaml
+++ b/deploy/charts/imagepullsecrets/values.yaml
@@ -20,7 +20,7 @@ securityContext:
       - ALL
 image:
   repository: ghcr.io/banzaicloud/imagepullsecrets
-  tag: v0.3.10
+  tag: v0.3.11
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.10.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.1.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.0
-	github.com/banzaicloud/imps/api v0.3.10
+	github.com/banzaicloud/imps/api v0.3.11
 	github.com/cisco-open/operator-tools v0.29.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/pflag v1.0.5


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0

### What's in this PR?
Bump helm chart and api version to `0.3.11`

### Why?
Includes fixes for imps and imps-refresher

### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)