### PR TITLE
IMPS and IMPS-refresh fix RHOS preflight check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,8 @@ FROM redhat/ubi8-micro:8.7@sha256:6a56010de933f172b195a1a575855d37b70a4968be8edb
 ARG UID
 ARG GID
 
-COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /usr/local/src/imps/LICENSE /usr/local/src/imps/LICENSE
+COPY --from=builder /usr/local/src/imps/LICENSE /licenses/LICENSE
 
 COPY --from=builder /usr/local/bin/manager /manager
 
@@ -58,9 +57,8 @@ FROM gcr.io/distroless/base-debian11:latest@sha256:e711a716d8b7fe9c4f7bbf1477e8e
 ARG UID
 ARG GID
 
-COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /usr/local/src/imps/LICENSE /usr/local/src/imps/LICENSE
+COPY --from=builder /usr/local/src/imps/LICENSE /licenses/LICENSE
 
 COPY --from=builder /usr/local/bin/manager /manager
 

--- a/Dockerfile-refresher
+++ b/Dockerfile-refresher
@@ -41,9 +41,8 @@ FROM redhat/ubi8-micro:8.7@sha256:6a56010de933f172b195a1a575855d37b70a4968be8edb
 ARG UID
 ARG GID
 
-COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /usr/local/src/imps/LICENSE /usr/local/src/imps/LICENSE
+COPY --from=builder /usr/local/src/imps/LICENSE /licenses/LICENSE
 
 COPY --from=builder /usr/local/bin/manager /manager
 
@@ -58,9 +57,8 @@ FROM gcr.io/distroless/base-debian11:latest@sha256:e711a716d8b7fe9c4f7bbf1477e8e
 ARG UID
 ARG GID
 
-COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /usr/local/src/imps/LICENSE /usr/local/src/imps/LICENSE
+COPY --from=builder /usr/local/src/imps/LICENSE /licenses/LICENSE
 
 COPY --from=builder /usr/local/bin/manager /manager
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes RHOS pre-flight check for certification
| License         | Apache 2.0

### What's in this PR?
1. Fix License path
2. Remove `/usr/share/zoneinfo` copy on base image.

### Why?
1. License was not found during pre-flight check
2. We were modifying `/usr/share/zoneinfo` on base image. Base image files should not be modified

### Additional context
Passes `HasModifiedFiles` pre-flight check required for RedHat Certification

### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### Testing
```
time="2023-04-20T11:00:14-07:00" level=info msg="certification library version" version="0.0.0 <commit: c4836d6660ee99226dd1cb655c693928d3ae3044>"
time="2023-04-20T11:00:14-07:00" level=info msg="target image" image="docker.io/xxxx/imagepullsecrets:v0.3.11-ubi"
time="2023-04-20T11:00:20-07:00" level=info msg="check completed" check=HasLicense result=PASSED
time="2023-04-20T11:00:20-07:00" level=info msg="check completed" check=HasUniqueTag result=PASSED
time="2023-04-20T11:00:20-07:00" level=info msg="check completed" check=LayerCountAcceptable result=PASSED
time="2023-04-20T11:00:20-07:00" level=info msg="check completed" check=HasNoProhibitedPackages result=PASSED
time="2023-04-20T11:00:20-07:00" level=info msg="check completed" check=HasRequiredLabel result=PASSED
time="2023-04-20T11:00:20-07:00" level=info msg="USER 1000:1000 specified that is non-root"
time="2023-04-20T11:00:20-07:00" level=info msg="check completed" check=RunAsNonRoot result=PASSED
time="2023-04-20T11:00:21-07:00" level=info msg="check completed" check=HasModifiedFiles result=PASSED
time="2023-04-20T11:00:22-07:00" level=info msg="check completed" check=BasedOnUbi result=PASSED
time="2023-04-20T11:00:22-07:00" level=info msg="This image's tag v0.3.11-ubi will be paired with digest sha256:b5901265b277d6a069e9b3b1054a046fe5c735064ceccd307be492f2a987790b once this image has been published in accordance with Red Hat Certification policy. You may then add or remove any supplemental tags through your Red Hat Connect portal as you see fit."
{
    "image": "docker.io/nishantapatil3/imagepullsecrets:v0.3.11-ubi",
    "passed": true,
    "test_library": {
        "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
        "version": "0.0.0",
        "commit": "c4836d6660ee99226dd1cb655c693928d3ae3044"
    },
    "results": {
        "passed": [
            {
                "name": "HasLicense",
                "elapsed_time": 0,
                "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses"
            },
            {
                "name": "HasUniqueTag",
                "elapsed_time": 0,
                "description": "Checking if container has a tag other than 'latest', so that the image can be uniquely identified."
            },
            {
                "name": "LayerCountAcceptable",
                "elapsed_time": 0,
                "description": "Checking if container has less than 40 layers.  Too many layers within the container images can degrade container performance."
            },
            {
                "name": "HasNoProhibitedPackages",
                "elapsed_time": 10,
                "description": "Checks to ensure that the image in use does not include prohibited packages, such as Red Hat Enterprise Linux (RHEL) kernel packages."
            },
            {
                "name": "HasRequiredLabel",
                "elapsed_time": 0,
                "description": "Checking if the required labels (name, vendor, version, release, summary, description) are present in the container metadata."
            },
            {
                "name": "RunAsNonRoot",
                "elapsed_time": 0,
                "description": "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication"
            },
            {
                "name": "HasModifiedFiles",
                "elapsed_time": 1105,
                "description": "Checks that no files installed via RPM in the base Red Hat layer have been modified"
            },
            {
                "name": "BasedOnUbi",
                "elapsed_time": 1635,
                "description": "Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI)"
            }
        ],
        "failed": [],
        "errors": []
    }
}
time="2023-04-20T11:00:22-07:00" level=info msg="Preflight result: PASSED"
```